### PR TITLE
Added a generic terminal command for debian based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This is a simple [pomodoro timer](https://en.wikipedia.org/wiki/Pomodoro_Techniq
 	$ python pomodoro.py
 	
 <p> Do not put the files in different directories, in order to ensure pomodoro.py works fine.
-<p><b> You need a debian derivate OS to run pomodoro </b>
+<p><b> You need a debian derivate distro to run pomodoro </b>
 
 <h1><b> I hope this helps you (◡‿◡✿)</b></h1>

--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ This is a simple [pomodoro timer](https://en.wikipedia.org/wiki/Pomodoro_Techniq
 	$ python pomodoro.py
 	
 <p> Do not put the files in different directories, in order to ensure pomodoro.py works fine.
+<p><b> You need a debian derivate OS to run pomodoro </b>
 
 <h1><b> I hope this helps you (◡‿◡✿)</b></h1>

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -1,25 +1,34 @@
 import time
 import os
 
+def minutes_to_seconds(minutes):
+	"""
+	A function that converts minutes to seconds
+	
+	:param minutes: The number of minutes do be converted
+	:return: The number of seconds in a give number of minutes
+	"""
+	return 60 * minutes
+
 print ("Pomodoro started")
 
-time_to_work = 60 * 25  # 60 - seconds in 1 minute | 25 - minutes to work
-time_to_rest = 60 * 5 # 60 - seconds in 1 minute | 5 - minutes to rest
-end_of_pomodoro = 60 * 30 # 60 - seconds in 1 minute | 30 - minutes to rest
+time_to_work = minutes_to_seconds(25)
+time_to_rest = minutes_to_seconds(5)
+end_of_pomodoro = minutes_to_seconds(30)
 
 new_pomodoro = True;
 
 while (new_pomodoro):
 	for i in range(0, 3):
 		time.sleep(time_to_work);
-		os.system("gnome-terminal -e 'bash -c \"python print_rest.py; exec bash\"'")
+		os.system("x-terminal-emulator -e 'bash -c \"python print_rest.py; exec bash\"'")
 		time.sleep(time_to_rest);
-		os.system("gnome-terminal -e 'bash -c \"python print_work.py; exec bash\"'")
+		os.system("x-terminal-emulator -e 'bash -c \"python print_work.py; exec bash\"'")
 
 	time.sleep(time_to_work);
-	os.system("gnome-terminal -e 'bash -c \"python print_rest.py; exec bash\"'")
+	os.system("x-terminal-emulator -e 'bash -c \"python print_rest.py; exec bash\"'")
 	time.sleep(end_of_pomodoro);
-	os.system("gnome-terminal -e 'bash -c \"python print_work.py; exec bash\"'")
+	os.system("x-terminal-emulator -e 'bash -c \"python print_work.py; exec bash\"'")
 	
 	new_pomodoro = raw_input("Do you want to start a new pomodoro? (y/n) ")
 	


### PR DESCRIPTION
In debian, the `x-terminal-emulator` command opens the user's default terminal, which can be Konsole, gnome-terminal, and so on.