### PR TITLE
Added compatible terminal emulator for MacOSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This is a simple [pomodoro timer](https://en.wikipedia.org/wiki/Pomodoro_Techniq
 	$ python pomodoro.py
 	
 <p> Do not put the files in different directories, in order to ensure pomodoro.py works fine.
-<p><b> You need a debian derivate distro to run pomodoro </b>
+<p><b> You need a debian derivate distro or MacOSX to run pomodoro </b>
 
 <h1><b> I hope this helps you (◡‿◡✿)</b></h1>

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -1,7 +1,6 @@
 import time
 import os
 from sys import platform as _platform
-import subprocess
 
 def minutes_to_seconds(minutes):
 	"""

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -1,5 +1,7 @@
 import time
 import os
+from sys import platform as _platform
+import subprocess
 
 def minutes_to_seconds(minutes):
 	"""
@@ -24,8 +26,10 @@ def open_terminal(python_script, time_to_close=5):
         :param time_to_close: the number of seconds before closing
         the new terminal
         """
-
-        os.system("x-terminal-emulator -e 'bash -c \"python %s  %d; exec bash\"'" % (python_script, time_to_close))
+        if _platform == "darwin":  #macOS
+            os.system("xterm -e 'bash -c \"python %s  %d; exec bash\"'" % (python_script, time_to_close))
+        else:
+            os.system("x-terminal-emulator -e 'bash -c \"python %s  %d; exec bash\"'" % (python_script, time_to_close))
 
 
 def work(time_to_work=TIME_TO_WORK):


### PR DESCRIPTION
Added Xterm emulator to work in MacOSX. Now Pomodoro can know which OS is running the script and execute the appropriate terminal emulator for the current OS.