### PR TITLE
Fixed inconsistent use of tabs and spaces in indentation error in pomodoro.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": false
+}

--- a/pomodoro.py
+++ b/pomodoro.py
@@ -45,14 +45,14 @@ print ("Pomodoro started")
 
 new_pomodoro = True;
 while (new_pomodoro):
-	for i in range(0, 3):
-                work()
-                rest()
+    for i in range(0, 3):
         work()
-        rest(END_OF_POMODORO)
-	
-	new_pomodoro = raw_input("Do you want to start a new pomodoro? (y/n) ")
-	if new_pomodoro == "y":
-		new_pomodoro = True;
-	else:
-		new_pomodoro = False;
+        rest()
+    work()
+    rest(END_OF_POMODORO)
+
+    new_pomodoro = raw_input("Do you want to start a new pomodoro? (y/n) ")
+    if new_pomodoro == "y":
+        new_pomodoro = True;
+    else:
+        new_pomodoro = False;


### PR DESCRIPTION
Deleted invalid indentations and spaces in [`pomodoro.py`](https://github.com/marianabianca/pomodoro/blob/master/pomodoro.py) and now it runs perfectly.

Resolves #7 .